### PR TITLE
Save ops points and control for each country in a game

### DIFF
--- a/app/assets/javascripts/country_scores.coffee
+++ b/app/assets/javascripts/country_scores.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/country_scores.scss
+++ b/app/assets/stylesheets/country_scores.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the CountryScores controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/country_scores_controller.rb
+++ b/app/controllers/country_scores_controller.rb
@@ -1,0 +1,15 @@
+class CountryScoresController < InheritedResources::Base
+
+  private
+
+  def country_score_params
+    params.require(:country_score).permit(:us_influence,
+                                          :ussr_influence,
+                                          :country_id,
+                                          :game_id,
+                                          :controlled_by
+                                         )
+  end
+
+end
+

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,9 +1,72 @@
 class GamesController < InheritedResources::Base
 
+  before_action :load_game, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @games = current_user.games
+  end
+
+  def new
+    @game = current_user.games.new
+  end
+
+  def create
+    @game = Game.new(game_params)
+
+    respond_to do |format|
+      if @game.save
+        format.html { redirect_to @game, notice: "Game was successfully created." }
+        format.json { render action: "show", status: :created, location: @game }
+      else
+        format.html { flash.now[:danger] = "Please check your entry and try again."
+                      render :new
+                    }
+        format.json { render json: @game.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def show
+    render
+  end
+
+  def edit
+    render
+  end
+
+  def update
+    respond_to do |format|
+      if @game.update(game_params)
+        format.html { redirect_to game_path, notice: "Game was successfully updated." }
+        format.json { head :no_content }
+      else
+        format.html { flash.now[:danger] = "Please check your entry and try again."
+                      render :edit
+                    }
+        format.json { render json: @game.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @game.destroy
+    respond_to do |format|
+      format.html { redirect_to games_url }
+      format.json { head :no_content }
+    end
+  end
+
   private
 
-    def game_params
-      params.require(:game).permit(:player_us_id, :player_ussr_id, :status)
-    end
-end
+  def load_game
+    @game = Game.find(params[:id])
+  end
 
+  def game_params
+    params.require(:game).permit(:player_us_id,
+                                 :player_ussr_id,
+                                 :status
+                                )
+  end
+
+end

--- a/app/helpers/country_scores_helper.rb
+++ b/app/helpers/country_scores_helper.rb
@@ -1,0 +1,2 @@
+module CountryScoresHelper
+end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -4,6 +4,7 @@ class Country < ActiveRecord::Base
   has_many :regions, through: :vicinities
   has_many :connections
   has_many :neighbors, through: :connections
+  has_many :country_scores
 
   accepts_nested_attributes_for :vicinities
   accepts_nested_attributes_for :connections

--- a/app/models/country_score.rb
+++ b/app/models/country_score.rb
@@ -1,0 +1,22 @@
+class CountryScore < ActiveRecord::Base
+
+  belongs_to :country
+  belongs_to :game
+
+  validates :country, :game, presence: true
+
+  def us_controlled?
+    us = us_influence
+    ussr = ussr_influence
+    stability = country.stability
+    us >= stability && us >= ussr + stability
+  end
+
+  def ussr_controlled?
+    us = us_influence
+    ussr = ussr_influence
+    stability = country.stability
+    ussr >= stability && ussr >= us + stability
+  end
+
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,4 +3,19 @@ class Game < ActiveRecord::Base
   belongs_to :player_us, class_name: "User", inverse_of: :us_games
   belongs_to :player_ussr, class_name: "User", inverse_of: :ussr_games
 
+  has_many :country_scores
+
+  validates :player_us, :player_ussr, presence: true
+
+  after_create :initialize_country_scores
+
+  scope :user_is_participant, ->(user) { where("(player_us_id = ?) OR (player_ussr_id = ?)", user, user) }
+
+  def initialize_country_scores
+    countries = Country.all
+    countries.each do |country|
+      CountryScore.create!(game: self, country: country)
+    end
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,17 +16,21 @@ class User < ActiveRecord::Base
   validates :email, uniqueness: true
 
   def name
-    [first_name, last_name].join(' ').strip
+    [first_name, last_name].join(" ").strip
   end
 
   def super_admin?
-    role == 'super_admin'
+    role == "super_admin"
   end
 
-  def as_json( options = {} )
-    new_options = options.merge({ only: [:email, :first_name, :last_name, :current_sign_in_at] })
+  def as_json(options={})
+    new_options = options.merge(only: [:email, :first_name, :last_name, :current_sign_in_at])
 
     super new_options
+  end
+
+  def games
+    Game.user_is_participant(self.id)
   end
 
   private

--- a/app/services/util.rb
+++ b/app/services/util.rb
@@ -1,0 +1,16 @@
+class Util
+
+  def self.log_exception exception
+    msg = exception.class.to_s; log msg
+    msg = exception.to_s; log msg
+    exception.backtrace.each do |line|
+      log line
+    end
+  end
+
+  def self.log msg
+    Rails.logger.info msg
+    puts msg
+  end
+  
+end

--- a/app/views/country_scores/_form.html.haml
+++ b/app/views/country_scores/_form.html.haml
@@ -1,0 +1,22 @@
+= form_for @country_score do |f|
+  - if @country_score.errors.any?
+    #error_explanation
+      %h2= "#{pluralize(@country_score.errors.count, "error")} prohibited this country_score from being saved:"
+      %ul
+        - @country_score.errors.full_messages.each do |msg|
+          %li= msg
+
+  .field
+    = f.label :us_influence
+    = f.number_field :us_influence
+  .field
+    = f.label :ussr_influence
+    = f.number_field :ussr_influence
+  .field
+    = f.label :country
+    = f.text_field :country
+  .field
+    = f.label :game
+    = f.text_field :game
+  .actions
+    = f.submit 'Save'

--- a/app/views/country_scores/edit.html.haml
+++ b/app/views/country_scores/edit.html.haml
@@ -1,0 +1,7 @@
+%h1 Editing country_score
+
+= render 'form'
+
+= link_to 'Show', @country_score
+\|
+= link_to 'Back', country_scores_path

--- a/app/views/country_scores/index.html.haml
+++ b/app/views/country_scores/index.html.haml
@@ -1,0 +1,27 @@
+%h1 Listing country_scores
+
+%table
+  %thead
+    %tr
+      %th Us influence
+      %th Ussr influence
+      %th Country
+      %th Game
+      %th
+      %th
+      %th
+      
+  %tbody
+    - @country_scores.each do |country_score|
+      %tr
+        %td= country_score.us_influence
+        %td= country_score.ussr_influence
+        %td= country_score.country
+        %td= country_score.game
+        %td= link_to 'Show', country_score
+        %td= link_to 'Edit', edit_country_score_path(country_score)
+        %td= link_to 'Destroy', country_score, :method => :delete, :data => { :confirm => 'Are you sure?' }
+
+%br
+
+= link_to 'New Country score', new_country_score_path

--- a/app/views/country_scores/index.json.jbuilder
+++ b/app/views/country_scores/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@country_scores) do |country_score|
+  json.extract! country_score, :id, :us_influence, :ussr_influence, :country_id, :game_id
+  json.url country_score_url(country_score, format: :json)
+end

--- a/app/views/country_scores/new.html.haml
+++ b/app/views/country_scores/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New country_score
+
+= render 'form'
+
+= link_to 'Back', country_scores_path

--- a/app/views/country_scores/show.html.haml
+++ b/app/views/country_scores/show.html.haml
@@ -1,0 +1,18 @@
+%p#notice= notice
+
+%p
+  %b Us influence:
+  = @country_score.us_influence
+%p
+  %b Ussr influence:
+  = @country_score.ussr_influence
+%p
+  %b Country:
+  = @country_score.country
+%p
+  %b Game:
+  = @country_score.game
+
+= link_to 'Edit', edit_country_score_path(@country_score)
+\|
+= link_to 'Back', country_scores_path

--- a/app/views/country_scores/show.json.jbuilder
+++ b/app/views/country_scores/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @country_score, :id, :us_influence, :ussr_influence, :country_id, :game_id, :created_at, :updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 TwilightStruggle::Application.routes.draw do
 
+  resources :country_scores
+
   resources :games
 
   resources :regions

--- a/db/migrate/20150111193019_create_country_scores.rb
+++ b/db/migrate/20150111193019_create_country_scores.rb
@@ -1,0 +1,14 @@
+class CreateCountryScores < ActiveRecord::Migration
+
+  def change
+    create_table :country_scores do |t|
+      t.integer :us_influence, default: 0
+      t.integer :ussr_influence, default: 0
+      t.references :country, index: true
+      t.references :game, index: true
+
+      t.timestamps
+    end
+  end
+
+end

--- a/db/migrate/20150111212335_add_control_to_country_score.rb
+++ b/db/migrate/20150111212335_add_control_to_country_score.rb
@@ -1,0 +1,7 @@
+class AddControlToCountryScore < ActiveRecord::Migration
+
+  def change
+    add_column :country_scores, :controlled_by, :string
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150110161241) do
+ActiveRecord::Schema.define(version: 20150111212335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,19 @@ ActiveRecord::Schema.define(version: 20150110161241) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "country_scores", force: true do |t|
+    t.integer  "us_influence",   default: 0
+    t.integer  "ussr_influence", default: 0
+    t.integer  "country_id"
+    t.integer  "game_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "controlled_by"
+  end
+
+  add_index "country_scores", ["country_id"], name: "index_country_scores_on_country_id", using: :btree
+  add_index "country_scores", ["game_id"], name: "index_country_scores_on_game_id", using: :btree
 
   create_table "delayed_jobs", force: true do |t|
     t.integer  "priority",   default: 0

--- a/test/controllers/country_scores_controller_test.rb
+++ b/test/controllers/country_scores_controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class CountryScoresControllerTest < ActionController::TestCase
+  setup do
+    @country_score = country_scores(:one)
+  end
+
+  test "should get index" do
+    get :index
+    assert_response :success
+    assert_not_nil assigns(:country_scores)
+  end
+
+  test "should get new" do
+    get :new
+    assert_response :success
+  end
+
+  test "should create country_score" do
+    assert_difference('CountryScore.count') do
+      post :create, country_score: { country_id: @country_score.country_id, game_id: @country_score.game_id, us_influence: @country_score.us_influence, ussr_influence: @country_score.ussr_influence }
+    end
+
+    assert_redirected_to country_score_path(assigns(:country_score))
+  end
+
+  test "should show country_score" do
+    get :show, id: @country_score
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get :edit, id: @country_score
+    assert_response :success
+  end
+
+  test "should update country_score" do
+    patch :update, id: @country_score, country_score: { country_id: @country_score.country_id, game_id: @country_score.game_id, us_influence: @country_score.us_influence, ussr_influence: @country_score.ussr_influence }
+    assert_redirected_to country_score_path(assigns(:country_score))
+  end
+
+  test "should destroy country_score" do
+    assert_difference('CountryScore.count', -1) do
+      delete :destroy, id: @country_score
+    end
+
+    assert_redirected_to country_scores_path
+  end
+end

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -1,8 +1,11 @@
 require 'test_helper'
 
 class GamesControllerTest < ActionController::TestCase
-  setup do
+
+  def setup
     @game = games(:one)
+    @patrick = users(:patrick)
+    sign_in @patrick
   end
 
   test "should get index" do
@@ -46,4 +49,5 @@ class GamesControllerTest < ActionController::TestCase
 
     assert_redirected_to games_path
   end
+
 end

--- a/test/fixtures/countries.yml
+++ b/test/fixtures/countries.yml
@@ -9,3 +9,8 @@ two:
   name: MyString
   stability: 1
   battleground: false
+
+mexico:
+  name: Mexico
+  stability: 2
+  battleground: true

--- a/test/fixtures/country_scores.yml
+++ b/test/fixtures/country_scores.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  us_influence: 1
+  ussr_influence: 1
+  country: mexico
+  game: patrick_vs_mike
+
+two:
+  us_influence: 1
+  ussr_influence: 1
+  country_id: 
+  game_id: 
+
+patrick_vs_mike_mexico:
+  game: patrick_vs_mike
+  country: mexico
+  us_influence: 3
+  ussr_influence: 0

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,11 +1,16 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  player_us_id: 1
-  player_ussr_id: 1
+  player_us: nancy
+  player_ussr: admin
   status: MyString
 
 two:
-  player_us_id: 1
-  player_ussr_id: 1
+  player_us: nancy
+  player_ussr: admin
   status: MyString
+
+patrick_vs_mike:
+  player_us: patrick
+  player_ussr: mike
+  status: Active

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,14 +3,30 @@ admin:
   first_name: 'Adam'
   last_name: 'Smith'
   encrypted_password: '$2a$10$3OF9YyLG6D8P8EqFFdudmeIUtIlnX2usIFYhAJ77pep5y93BLuSuu' #welcome
-  reset_password_token: 5h632xrnASqFanDhKQsB8
+  reset_password_token: 5h632xrnASqFanDhKQsB7
   role: 'super_admin'
-  authentication_token: 5h632xrnASqFanDhKQsB8
+  authentication_token: 5h632xrnASqFanDhKQsB7
 
 nancy:
   email: nancy.smith@example.com
   first_name: 'Nancy'
   last_name: 'Smith'
   encrypted_password: '$2a$10$3OF9YyLG6D8P8EqFFdudmeIUtIlnX2usIFYhAJ77pep5y93BLuSuu' #welcome
-  reset_password_token: 5h632xrnASsFanDhKQsB7
+  reset_password_token: 5h632xrnASsFanDhKQsB8
   authentication_token: 5h632xrnASqFanDhKQsB8
+
+patrick:
+  email: ogradypatrickj@gmail.com
+  first_name: Patrick
+  last_name: "O'Grady"
+  encrypted_password: '$2a$10$3OF9YyLG6D8P8EqFFdudmeIUtIlnX2usIFYhAJ77pep5y93BLuSuu' #welcome
+  reset_password_token: 5h632xrnASsFanDhKQsB9
+  authentication_token: 5h632xrnASqFanDhKQsB9
+
+mike:
+  email: mdfantis@gmail.com
+  first_name: Mike
+  last_name: "D'Fantis"
+  encrypted_password: '$2a$10$3OF9YyLG6D8P8EqFFdudmeIUtIlnX2usIFYhAJ77pep5y93BLuSuu' #welcome
+  reset_password_token: 5h632xrnASsFanDhKQsB10
+  authentication_token: 5h632xrnASqFanDhKQsB10

--- a/test/helpers/country_scores_helper_test.rb
+++ b/test/helpers/country_scores_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class CountryScoresHelperTest < ActionView::TestCase
+end

--- a/test/models/country_score_test.rb
+++ b/test/models/country_score_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class CountryScoreTest < ActiveSupport::TestCase
+
+  fixtures :games, :countries
+
+  def test_us_controlled_true
+    mexico = countries(:mexico)
+    game = games(:patrick_vs_mike)
+    mexico_score = CountryScore.create!(country: mexico,
+                                        game: game,
+                                        us_influence: 10,
+                                        ussr_influence: 0
+                                       )
+    assert_equal true, mexico_score.us_controlled?
+  end
+
+  def test_us_controlled_false
+    mexico = countries(:mexico)
+    game = games(:patrick_vs_mike)
+    mexico_score = CountryScore.create!(country: mexico,
+                                        game: game,
+                                        us_influence: 0,
+                                        ussr_influence: 0
+                                       )
+    assert_equal false, mexico_score.us_controlled?
+  end
+
+  def test_ussr_controlled_true
+    mexico = countries(:mexico)
+    game = games(:patrick_vs_mike)
+    mexico_score = CountryScore.create!(country: mexico,
+                                        game: game,
+                                        us_influence: 0,
+                                        ussr_influence: 10
+                                       )
+    assert_equal true, mexico_score.ussr_controlled?
+  end
+
+  def test_ussr_controlled_false
+    mexico = countries(:mexico)
+    game = games(:patrick_vs_mike)
+    mexico_score = CountryScore.create!(country: mexico,
+                                        game: game,
+                                        us_influence: 10,
+                                        ussr_influence: 0
+                                       )
+    assert_equal false, mexico_score.ussr_controlled?
+  end
+
+end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,7 +1,5 @@
-require 'test_helper'
+require "test_helper"
 
 class GameTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,8 @@
-require 'test_helper'
+require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
+
+  fixtures :users, :games
 
   def test_admin_is_indeed_super_admin
     user = users :admin
@@ -10,20 +12,27 @@ class UserTest < ActiveSupport::TestCase
   def test_first_name_is_blank
     user = users :admin
     user.first_name = nil
-    assert_equal 'Smith', user.name
+    assert_equal "Smith", user.name
   end
 
   def test_last_name_is_blank
     user = users :admin
     user.last_name = nil
-    assert_equal 'Adam', user.name
+    assert_equal "Adam", user.name
   end
 
   def test_as_json
     user = users :admin
 
-    expected = {"email"=>"admin@example.com", "current_sign_in_at"=>nil, "last_name"=>"Smith", "first_name"=>"Adam"}
+    expected = { "email" => "admin@example.com", "current_sign_in_at" => nil,
+                 "last_name" => "Smith", "first_name" => "Adam"
+               }
     assert_equal expected, user.as_json
+  end
+
+  def test_games
+    user = users(:patrick)
+    assert_equal 1, user.games.count
   end
 
 end


### PR DESCRIPTION
- [x] Create country_score scaffold
- [x] When a new game is created, generate a country_score object for each country, to track ops points and control of each country on the map
